### PR TITLE
User-input quality level, disable chroma subsampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ python3 tile_fetch.py --zoom 4 "https://artsandculture.google.com/asset/the-wate
 You can of course change the zoom level and the URL.
 If you omit the zoom level, the script will display the list of available levels.
 
+Run with the '-h' flag for a list of available commands.
+
 ## Technical details
 
 This project required reverse-engineering google's code to find 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ python3 tile_fetch.py --zoom 4 "https://artsandculture.google.com/asset/the-wate
 You can of course change the zoom level and the URL.
 If you omit the zoom level, the script will display the list of available levels.
 
-Run with the '-h' flag for a list of available commands.
-
 ## Technical details
 
 This project required reverse-engineering google's code to find 

--- a/tile_fetch.py
+++ b/tile_fetch.py
@@ -7,7 +7,6 @@ import io
 import itertools
 import re
 import shutil
-import string
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -49,7 +48,7 @@ class ImageInfo(object):
 
         url_path = urllib.parse.unquote_plus(urllib.parse.urlparse(url).path)
         self.image_slug, image_id = url_path.split('/')[-2:]
-        self.image_name = '%s - %s' % (string.capwords(self.image_slug.replace("-"," ")), image_id)
+        self.image_name = '%s - %s' % (self.image_slug, image_id)
 
         meta_info_url = "https:{}=g".format(url_no_proto.decode('utf8'))
         meta_info_tree = etree.fromstring(urllib.request.urlopen(meta_info_url).read())
@@ -102,7 +101,7 @@ async def fetch_tile(session, image_info, tiles_dir, x, y, z):
     return x, y, encrypted_bytes
 
 
-async def load_tiles(info, z=-1, outfile=None, quality=90):
+async def load_tiles(info, z=-1, outfile=None, q=95):
     if z >= len(info.tile_info):
         print(
             'Invalid zoom level {z}. '
@@ -110,7 +109,7 @@ async def load_tiles(info, z=-1, outfile=None, quality=90):
                 z=z,
                 max=len(info.tile_info) - 1)
         )
-        z = len(info.tile_info) - 1
+        z = len(info.tile_info) - 1 
 
     z %= len(info.tile_info)  # keep 0 <= z < len(tile_info)
     level = info.tile_info[z]
@@ -137,7 +136,7 @@ async def load_tiles(info, z=-1, outfile=None, quality=90):
 
     print("Downloaded all tiles. Saving...")
     final_image_filename = outfile or (info.image_name + '.jpg')
-    img.save(final_image_filename, quality=quality, subsampling=0)
+    img.save(final_image_filename, quality=q, subsampling=0)
     shutil.rmtree(tiles_dir)
     print("Saved the result as " + final_image_filename)
 
@@ -151,8 +150,6 @@ def main():
                         help='Zoom level to fetch, can be negative. Will print zoom levels if omitted')
     parser.add_argument('--outfile', type=str, nargs='?',
                         help='The name of the file to create.')
-    parser.add_argument('--quality', type=int, nargs='?', default='90',
-                        help='Compression level from 0-95. Higher is better.')
     args = parser.parse_args()
 
     url = args.url or input("Enter the url of the image: ")
@@ -171,7 +168,13 @@ def main():
             except (ValueError, AssertionError):
                 print("Not a valid zoom level.")
 
-    coro = load_tiles(image_info, zoom, args.outfile, args.quality)
+    try:
+        comp_quality = int(input("What image quality would you like? (0-95, higher is better): "))
+        assert 0 <= comp_quality <= 95
+    except (ValueError, AssertionError):
+        print("Not a valid quality of compression. Please select a number from 0-95")
+
+    coro = load_tiles(image_info, zoom, args.outfile, comp_quality)
     loop = asyncio.get_event_loop()
     loop.run_until_complete(coro)
 

--- a/tile_fetch.py
+++ b/tile_fetch.py
@@ -101,7 +101,7 @@ async def fetch_tile(session, image_info, tiles_dir, x, y, z):
     return x, y, encrypted_bytes
 
 
-async def load_tiles(info, z=-1, outfile=None):
+async def load_tiles(info, z=-1, outfile=None, q=95):
     if z >= len(info.tile_info):
         print(
             'Invalid zoom level {z}. '
@@ -109,7 +109,7 @@ async def load_tiles(info, z=-1, outfile=None):
                 z=z,
                 max=len(info.tile_info) - 1)
         )
-        z = len(info.tile_info) - 1
+        z = len(info.tile_info) - 1 
 
     z %= len(info.tile_info)  # keep 0 <= z < len(tile_info)
     level = info.tile_info[z]
@@ -136,7 +136,7 @@ async def load_tiles(info, z=-1, outfile=None):
 
     print("Downloaded all tiles. Saving...")
     final_image_filename = outfile or (info.image_name + '.jpg')
-    img.save(final_image_filename)
+    img.save(final_image_filename, quality=q, subsampling=0)
     shutil.rmtree(tiles_dir)
     print("Saved the result as " + final_image_filename)
 
@@ -168,7 +168,13 @@ def main():
             except (ValueError, AssertionError):
                 print("Not a valid zoom level.")
 
-    coro = load_tiles(image_info, zoom, args.outfile)
+    try:
+        comp_quality = int(input("What image quality would you like? (0-95, higher is better): "))
+        assert 0 <= comp_quality <= 95
+    except (ValueError, AssertionError):
+        print("Not a valid quality of compression. Please select a number from 0-95")
+
+    coro = load_tiles(image_info, zoom, args.outfile, comp_quality)
     loop = asyncio.get_event_loop()
     loop.run_until_complete(coro)
 

--- a/tile_fetch.py
+++ b/tile_fetch.py
@@ -7,6 +7,7 @@ import io
 import itertools
 import re
 import shutil
+import string
 import urllib.parse
 import urllib.request
 from pathlib import Path
@@ -48,7 +49,7 @@ class ImageInfo(object):
 
         url_path = urllib.parse.unquote_plus(urllib.parse.urlparse(url).path)
         self.image_slug, image_id = url_path.split('/')[-2:]
-        self.image_name = '%s - %s' % (self.image_slug, image_id)
+        self.image_name = '%s - %s' % (string.capwords(self.image_slug.replace("-"," ")), image_id)
 
         meta_info_url = "https:{}=g".format(url_no_proto.decode('utf8'))
         meta_info_tree = etree.fromstring(urllib.request.urlopen(meta_info_url).read())
@@ -101,7 +102,7 @@ async def fetch_tile(session, image_info, tiles_dir, x, y, z):
     return x, y, encrypted_bytes
 
 
-async def load_tiles(info, z=-1, outfile=None, q=95):
+async def load_tiles(info, z=-1, outfile=None, quality=90):
     if z >= len(info.tile_info):
         print(
             'Invalid zoom level {z}. '
@@ -109,7 +110,7 @@ async def load_tiles(info, z=-1, outfile=None, q=95):
                 z=z,
                 max=len(info.tile_info) - 1)
         )
-        z = len(info.tile_info) - 1 
+        z = len(info.tile_info) - 1
 
     z %= len(info.tile_info)  # keep 0 <= z < len(tile_info)
     level = info.tile_info[z]
@@ -136,7 +137,7 @@ async def load_tiles(info, z=-1, outfile=None, q=95):
 
     print("Downloaded all tiles. Saving...")
     final_image_filename = outfile or (info.image_name + '.jpg')
-    img.save(final_image_filename, quality=q, subsampling=0)
+    img.save(final_image_filename, quality=quality, subsampling=0)
     shutil.rmtree(tiles_dir)
     print("Saved the result as " + final_image_filename)
 
@@ -150,6 +151,8 @@ def main():
                         help='Zoom level to fetch, can be negative. Will print zoom levels if omitted')
     parser.add_argument('--outfile', type=str, nargs='?',
                         help='The name of the file to create.')
+    parser.add_argument('--quality', type=int, nargs='?', default='90',
+                        help='Compression level from 0-95. Higher is better.')
     args = parser.parse_args()
 
     url = args.url or input("Enter the url of the image: ")
@@ -168,13 +171,7 @@ def main():
             except (ValueError, AssertionError):
                 print("Not a valid zoom level.")
 
-    try:
-        comp_quality = int(input("What image quality would you like? (0-95, higher is better): "))
-        assert 0 <= comp_quality <= 95
-    except (ValueError, AssertionError):
-        print("Not a valid quality of compression. Please select a number from 0-95")
-
-    coro = load_tiles(image_info, zoom, args.outfile, comp_quality)
+    coro = load_tiles(image_info, zoom, args.outfile, args.quality)
     loop = asyncio.get_event_loop()
     loop.run_until_complete(coro)
 


### PR DESCRIPTION
Default PIL compression level is 75 for JPEG's, user can choose 0-95. The original tiles have 4:2:0 chroma subsampling, but re-subsampling is disabed here - JPEG recompression with the same quality level causes minimal loss, but chroma re-subsampling causes continuous loss of color. See: https://photo.stackexchange.com/a/99605/85194